### PR TITLE
Default settings

### DIFF
--- a/Resource.h
+++ b/Resource.h
@@ -26,13 +26,21 @@
 #define IDC_SETHARD                     1005
 #define IDSTART                         1007
 #define IDRESTART                       1008
+#define IDC_SOUND                       1009
+#define IDC_STATICSTART2                1010
+#define IDC_STATICTEXT3                 1011
+#define IDC_STATICSTART3                1011
+#define IDC_STATICSTART1                1012
+#define IDC_STATICABOUT1                1013
+#define IDC_STATICABOUT2                1014
+#define IDC_STATICABOUT3                1015
 #define IDM_DIFFICULTY_EASY             32778
 #define IDM_DIFFICULTY_MEDIUM           32779
 #define IDM_DIFFICULTY_HARD             32780
 #define IDM_RESTART                     32782
 #define ID_OPTIONS_SOUND                32783
 #define IDM_OPTIONS_SOUND               32784
-#define IDC_STATIC                      -1
+#define IDI_ICONRS                      -1
 
 // Next default values for new objects
 // 
@@ -41,7 +49,7 @@
 #define _APS_NO_MFC                     1
 #define _APS_NEXT_RESOURCE_VALUE        138
 #define _APS_NEXT_COMMAND_VALUE         32785
-#define _APS_NEXT_CONTROL_VALUE         1009
+#define _APS_NEXT_CONTROL_VALUE         1016
 #define _APS_NEXT_SYMED_VALUE           110
 #endif
 #endif

--- a/Snake.cpp
+++ b/Snake.cpp
@@ -513,10 +513,28 @@ INT_PTR CALLBACK Startup(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
     case WM_INITDIALOG:
     {
         TheGame.TogglePause(true);
+        const BOOL SoundEnabled = TheGame.GetSoundEnabled();
+        UINT DefaultDifficulty = IDC_SETEASY;
+        switch (g_eDifficulty)
+        {
+        case DIFFICULTY::UNINIT:
+        case DIFFICULTY::EASY:
+            DefaultDifficulty = IDC_SETEASY;
+            break;
+        case DIFFICULTY::MEDIUM:
+            DefaultDifficulty = IDC_SETMEDIUM;
+            break;
+        case DIFFICULTY::HARD:
+            DefaultDifficulty = IDC_SETHARD;
+            break;
+        default:
+            break;
+        }
+         
         HICON hIcon = LoadIcon(g_hInst, MAKEINTRESOURCE(IDI_BLOCKSNAKE));
         SendMessage(hDlg, WM_SETICON, ICON_SMALL, (LPARAM)hIcon);
-        CheckDlgButton(hDlg,IDC_SOUND,TRUE);
-        CheckRadioButton(hDlg,IDC_SETEASY , IDC_SETHARD, IDC_SETEASY);
+        CheckDlgButton(hDlg,IDC_SOUND,SoundEnabled);
+        CheckRadioButton(hDlg,IDC_SETEASY , IDC_SETHARD, DefaultDifficulty);
         return (INT_PTR)TRUE;
     }
     case WM_COMMAND:

--- a/Snake.h
+++ b/Snake.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <afxwin.h>         // CButton, CString
 #include "resource.h"
 #include <utility>
 #define GRIDSIZE 50

--- a/Snake.rc
+++ b/Snake.rc
@@ -75,11 +75,11 @@ EXSTYLE WS_EX_TOPMOST
 CAPTION "About Snake"
 FONT 8, "MS Shell Dlg", 0, 0, 0x1
 BEGIN
-    ICON            IDI_ROUNDSNAKE,IDC_STATIC,14,14,21,20
-    LTEXT           "Snake, Version 1.0.2",IDC_STATIC,42,14,114,8,SS_NOPREFIX
-    LTEXT           "Copyright (c) 2020",IDC_STATIC,42,34,114,8
+    ICON            IDI_ROUNDSNAKE,IDI_ICONRS,14,14,21,20
+    LTEXT           "Snake, Version 1.0.2",IDC_STATICABOUT1,42,14,114,8,SS_NOPREFIX
+    LTEXT           "Copyright (c) 2020",IDC_STATICABOUT3,42,34,114,8
     DEFPUSHBUTTON   "OK",IDOK,114,42,50,14,WS_GROUP
-    LTEXT           "Created by CrustaShrimp",IDC_STATIC,42,24,114,8,SS_NOPREFIX
+    LTEXT           "Created by CrustaShrimp",IDC_STATICABOUT2,42,24,114,8,SS_NOPREFIX
 END
 
 
@@ -179,9 +179,10 @@ BEGIN
     CONTROL         "Easy",IDC_SETEASY,"Button",BS_AUTORADIOBUTTON,7,42,31,10
     CONTROL         "Medium",IDC_SETMEDIUM,"Button",BS_AUTORADIOBUTTON,7,55,40,10
     CONTROL         "Hard",IDC_SETHARD,"Button",BS_AUTORADIOBUTTON,7,68,31,10
-    LTEXT           "Welcome to Snake!",IDC_STATIC,62,7,61,8
-    LTEXT           "Select a difficulty and ",IDC_STATIC,7,22,72,8
-    LTEXT           "press Start:",IDC_STATIC,7,31,39,8
+    LTEXT           "Welcome to Snake!",IDC_STATICSTART1,62,7,61,8
+    LTEXT           "Select a difficulty and ",IDC_STATICSTART2,7,22,72,8
+    LTEXT           "press Start:",IDC_STATICSTART3,7,31,39,8
+    CONTROL         "Sound Enabled",IDC_SOUND,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,101,42,63,10
 END
 
 
@@ -209,6 +210,7 @@ BEGIN
         VERTGUIDE, 92
         TOPMARGIN, 7
         BOTTOMMARGIN, 95
+        HORZGUIDE, 47
     END
 END
 #endif    // APSTUDIO_INVOKED

--- a/Snake.vcxproj
+++ b/Snake.vcxproj
@@ -31,6 +31,7 @@
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>Dynamic</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -38,12 +39,14 @@
     <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>Dynamic</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>Dynamic</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -51,6 +54,7 @@
     <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
+    <UseOfMfc>Dynamic</UseOfMfc>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -72,25 +76,34 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)Bin\$(Configuration)\</OutDir>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <ShowIncludes>true</ShowIncludes>
+      <WarningVersion>
+      </WarningVersion>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -102,11 +115,15 @@
     <ClCompile>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <ShowIncludes>true</ShowIncludes>
+      <WarningVersion>
+      </WarningVersion>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -118,13 +135,17 @@
     <ClCompile>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <ShowIncludes>true</ShowIncludes>
+      <WarningVersion>
+      </WarningVersion>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -138,13 +159,17 @@
     <ClCompile>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <ShowIncludes>true</ShowIncludes>
+      <WarningVersion>
+      </WarningVersion>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
### General
I have made changes regarding some issue(s).

**Enter issue number(s) here**: #48 
This should fix the issue.
When starting the game, both the sound and difficulty have a default (on and uninitialised).
The sound and difficulty could have already been changed by the user if a new game is started after an initial game was played.
We can just check the sound and difficulty settings and use those as default for the starting screen.
In case it is the first time, sound is default on and the difficulty is set to uninitialised -> easy
In case it is not the first time, the sound and difficulty settings are initially the same as the previous game

I have:
- [ ] Added a new feature
- [X] Fixed a bug
